### PR TITLE
Better error handling for richclip

### DIFF
--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -18,7 +18,7 @@ pub struct CopyConfig<T: SourceData> {
     pub use_primary: bool,
     pub source_data: T,
     // For testing X INCR mode
-    pub x_chunk_size: usize
+    pub x_chunk_size: usize,
 }
 
 pub use wayland::{copy_wayland, paste_wayland};

--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -1,8 +1,8 @@
 use super::mime_type::decide_mime_type;
-use super::PasteConfig;
 use super::CopyConfig;
+use super::PasteConfig;
 use crate::protocol::SourceData;
-use anyhow::{Context, Error, Result, bail};
+use anyhow::{bail, Context, Error, Result};
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::fs::File;
@@ -266,8 +266,7 @@ fn wl_source_cb_for_copy(ctx: EventCtx<CopyEventState, ZwlrDataControlSourceV1>)
             log::debug!("Received 'Send' event");
             let src_data = ctx.state.source_data;
             let mut file = File::from(fd);
-            let (_, content) = src_data
-                .content_by_mime_type(mime_type.to_str().unwrap());
+            let (_, content) = src_data.content_by_mime_type(mime_type.to_str().unwrap());
             file.write_all(&content).unwrap();
         }
         zwlr_data_control_source_v1::Event::Cancelled => {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,7 +1,7 @@
-mod source_data;
 mod recv;
+mod source_data;
 
-pub use source_data::SourceData;
+pub use recv::receive_data;
 #[allow(unused_imports)]
 pub use recv::PROTOCAL_VER;
-pub use recv::receive_data;
+pub use source_data::SourceData;

--- a/src/protocol/recv.rs
+++ b/src/protocol/recv.rs
@@ -73,7 +73,7 @@ pub fn receive_data(mut reader: impl Read) -> Result<Vec<SourceDataItem>> {
                 let content = read_content(&mut reader)?;
                 ret.push(SourceDataItem {
                     mime_type: type_list,
-                    content: content.into()
+                    content: content.into(),
                 });
                 type_list = Vec::new();
             }


### PR DESCRIPTION
There're too many .unwrap() being used in richclip. This patch helps populate underlying errors to the main function, otherwise richclip will PANIC a lot.