### PR TITLE
Finally fix the wayland flaky paste

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +530,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +648,7 @@ dependencies = [
  "daemonize",
  "libc",
  "log",
+ "nix",
  "simplelog",
  "vergen-git2",
  "wayrs-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ libc = "0.2.168"
 xcb = { version = "1.5.0", features = [] }
 x11rb = { version = "0.13.1", features = [] }
 simplelog = "0.12.2"
+nix = "0.29.0"
 
 [build-dependencies]
 vergen-git2 = { version = "1.0.2", features = ["build", "cargo"] }

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -4,14 +4,13 @@ mod x;
 
 use super::protocol::SourceData;
 use std::io::Write;
-use std::os::fd::AsFd;
 
-pub struct PasteConfig<'a, T: AsFd + Write> {
+pub struct PasteConfig<'a, T: Write> {
     // Only list mime-types
     pub list_types_only: bool,
     pub use_primary: bool,
     pub expected_mime_type: String,
-    pub fd_to_write: &'a mut T,
+    pub writter: &'a mut T,
 }
 
 pub struct CopyConfig<T: SourceData> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,7 @@ fn do_paste(arg_matches: &ArgMatches) -> Result<()> {
         use_primary: *arg_matches
             .get_one::<bool>("primary")
             .context("`--primary` option is not specified for the `paste` command")?,
-        fd_to_write: &mut stdout(),
+        writter: &mut stdout(),
         expected_mime_type: t.to_string(),
     };
     match choose_backend() {


### PR DESCRIPTION
Quote from WlDataOffer.receive:
> The receiving client reads from the read end of the pipe until EOF
  and then closes its end, at which point the transfer is complete.

The original idea was passing the stdin as the write pipe fd to the
receive(). However, sometimes the clipboard content was not pasted when
the richclip was called in neovim. That could be caused that, neovim
does not read the stdout fast enough. Since when the receive call
finishes, it ends the loop and quite the program.

To fix this, just follow the doc to create a dedicated pipe.
BTW, I was too lazy to do this at the beginning, since I was not aware of
nix-rust at that time -- I didn't want to get hands dirty with 'unsafe'.
