### PR TITLE
Fix the "help" description

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn choose_backend() -> Backend {
     std::process::exit(1)
 }
 
-/// A fictional versioning CLI
+/// Clipboard utility for multiple platforms
 #[derive(Parser)]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
Amazingly this comment will be shown as the description of the "help"
sub-command.
