### PR TITLE
Add --one-shot mode for copy command

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,9 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Run bats test
-      run: bats test/bats/x
+      run: |
+        bats test/bats/x
+        bats test/bats/loopback
       shell: bash
       env:
         BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGES
 
+Next Release
+
+- Add `--one-shot` mode to allow copying data as it is from stdin.
+
 v0.2.1
 
 - The first public release.

--- a/README.md
+++ b/README.md
@@ -51,15 +51,23 @@ Options:
 ❯ richclip copy --help
 Receive and copy data to the clipboard
 Usage: richclip copy [OPTIONS]
+
 Options:
-  -p, --primary     Use the 'primary' clipboard
-      --foreground  Run in foreground
-  -h, --help        Print help
+  -p, --primary             Use the 'primary' clipboard
+      --foreground          Run in foreground
+      --one-shot            Enable one-shot mode, anything received from stdin will be copied as it is
+  -t, --type [<mime-type>]  Specify mime-type(s) to copy and implicitly enable one-shot copy mode
+  -h, --help                Print help
 ```
 
+#### Bulk mode copy
+
+By default, `richclip` receives data in bulk mode. In this mode, multiple formats
+of data can be copied to the clipboard with multiple mime-types. This allows
+the paste side to choose the favorite format of data to use.
+
 The data to be copied to the clipboard needs to follow a simple protocol which
-is described as below. A simpler transfer mode will be supported in the future
-for copying single type content like other clipboard utilities.
+is described as below.
 
 | Item             | Bytes    | Content             |
 |------------------| :------- | :------------------ |
@@ -84,3 +92,18 @@ for copying single type content like other clipboard utilities.
 - Every section starts with the section type, `M` (mime-type) or `C` (content).
 - Before `C` section, there must be one or more `M` section to indicate the data type.
 - Section length will be parsed as big-endian uint32 number.
+
+#### One-shot mode copy
+
+This is the traditional way to copy data like other clipboard utilities. The
+mime-types can be specified through the command line, and all data received
+through `stdin` will be copied as it is.
+
+```bash
+# Copy "TestData" to the clipboard, with default mime-type
+echo TestData | richclip copy --one-shot
+
+
+# Copy "<body>Haha</body>" to the clipboard, as "text/html" and "HTML"
+echo "<body>Haha</body>" | richclip copy --type "text/html" --type "HTML"
+```

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,7 +1,8 @@
 mod recv;
 mod source_data;
 
-pub use recv::receive_data;
+pub use recv::receive_data_bulk;
+pub use recv::receive_data_oneshot;
 #[allow(unused_imports)]
 pub use recv::PROTOCAL_VER;
 pub use source_data::SourceData;

--- a/src/protocol/source_data.rs
+++ b/src/protocol/source_data.rs
@@ -56,7 +56,7 @@ impl SourceData for Vec<SourceDataItem> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::receive_data;
+    use crate::protocol::receive_data_bulk;
     use crate::protocol::PROTOCAL_VER;
 
     #[test]
@@ -70,7 +70,7 @@ mod tests {
             b'M', 0, 0, 0, 9, b't', b'e', b'x', b't', b'/', b'h', b't', b'm', b'l',
             b'C', 0, 0, 0, 3, b'B', b'A', b'D',
             ];
-        let r = receive_data(&mut &buf[..]).unwrap();
+        let r = receive_data_bulk(&mut &buf[..]).unwrap();
 
         let (result, content) = r.content_by_mime_type("text/plain");
         assert!(result);

--- a/test/bats/loopback/loopback.bats
+++ b/test/bats/loopback/loopback.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+# Tests with own copy & paste. Ideally this would run on all platforms
+
+bats_require_minimum_version 1.5.0
+
+ROOT_DIR=$(realpath "$BATS_TEST_DIRNAME/../../..")
+RICHCLIP="$ROOT_DIR/target/debug/richclip"
+
+XVFB_PID=""
+
+setup_file() {
+    unset WAYLAND_DISPLAY
+    export DISPLAY=":42"
+    # Start a headless X server for testing
+    Xvfb $DISPLAY 3>&- &
+    XVFB_PID=$!
+    sleep 1
+    run -0 cargo build
+}
+
+teardown_file() {
+    if [ -n "$XVFB_PID" ]; then
+        kill "$XVFB_PID"
+    fi
+}
+
+teardown() {
+    killall -w richclip > /dev/null || echo ""
+}
+
+@test "one-shot mode:  no '--type'" {
+    # one-shot no type
+    echo "TestDaTA" | $RICHCLIP copy --one-shot
+
+    run -0 "$RICHCLIP" paste -l
+    [ "${lines[0]}" = "TARGETS" ]
+    [ "${lines[1]}" = "text/plain" ]
+    [ "${lines[2]}" = "text/plain;charset=utf-8" ]
+    [ "${lines[3]}" = "TEXT" ]
+    [ "${lines[4]}" = "STRING" ]
+    [ "${lines[5]}" = "UTF8_STRING" ]
+
+    run -0 "$RICHCLIP" paste
+    [ "$output" = "TestDaTA" ]
+}
+
+@test "one-shot mode:  with '--type'" {
+    # one-shot, one type
+    echo "TestDaTA" | $RICHCLIP copy --type TypE
+
+    run -0 "$RICHCLIP" paste -l
+    [ "${lines[0]}" = "TARGETS" ]
+    [ "${lines[1]}" = "TypE" ]
+
+    run -0 "$RICHCLIP" paste -t TypE
+    [ "$output" = "TestDaTA" ]
+
+    # one-shot, multi types
+    echo "TestDaTA" | $RICHCLIP copy --type TypE --type Faker
+    run -0 "$RICHCLIP" paste -l
+    [ "${lines[0]}" = "TARGETS" ]
+    [ "${lines[1]}" = "TypE" ]
+    [ "${lines[2]}" = "Faker" ]
+
+    run -0 "$RICHCLIP" paste -t Faker
+    [ "$output" = "TestDaTA" ]
+}


### PR DESCRIPTION
The default mode to copy data requires to assemble bytes in order to
follow the simple protocol, which is not easy for the simple command
line use case. "--one-shot" is added to make richclip work like
traditional clipboard utilities.
