### PR TITLE
Add cocoa pasteboard support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,10 +174,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cocoa"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
+dependencies = [
+ "bitflags",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
+dependencies = [
+ "bitflags",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "daemonize"
@@ -283,6 +359,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -537,6 +640,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +679,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -649,10 +770,12 @@ version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
+ "cocoa",
  "daemonize",
  "libc",
  "log",
  "nix",
+ "objc",
  "simplelog",
  "vergen-git2",
  "wayrs-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ daemonize = "0.5.0"
 log = "0.4.22"
 libc = "0.2.168"
 simplelog = "0.12.2"
+objc = "0.2.7"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 wayrs-client = { version = "1.1.3" }
@@ -21,6 +22,7 @@ nix = "0.29.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 x11rb = { version = "0.13.1", features = [] }
+cocoa = { version = "0.26.0" }
 
 [build-dependencies]
 vergen-git2 = { version = "1.0.2", features = ["build", "cargo"] }

--- a/src/clipboard/mac.rs
+++ b/src/clipboard/mac.rs
@@ -1,0 +1,168 @@
+#![cfg(target_os = "macos")]
+
+use super::ClipBackend;
+use super::CopyConfig;
+use super::PasteConfig;
+use anyhow::{bail, Context, Result};
+
+use cocoa::appkit;
+use cocoa::appkit::NSPasteboard;
+use cocoa::base::id;
+use cocoa::base::nil;
+use cocoa::foundation::NSArray;
+use cocoa::foundation::NSData;
+use cocoa::foundation::NSString;
+use cocoa::foundation::NSAutoreleasePool;
+
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::sync::LazyLock;
+
+// cocoa's pasteboard system is strange, just support what is needed for now.
+// See https://developer.apple.com/documentation/appkit/nspasteboard/pasteboardtype
+static SUPPORTED_TYPES_MAP: LazyLock<HashMap<String, Vec<&str>>> = unsafe {
+    LazyLock::new(|| {
+        HashMap::from([
+            (
+                nsstring_to_string(cocoa::appkit::NSPasteboardTypeString),
+                vec![
+                    "public.utf8-plain-text",
+                    "text/plain;charset=utf-8",
+                    "text/plain",
+                    "text",
+                    "string",
+                    "utf8_string",
+                ],
+            ),
+            (
+                nsstring_to_string(cocoa::appkit::NSPasteboardTypeHTML),
+                vec![
+                    "public.html",
+                    "text/html;charset=utf-8",
+                    "text/html",
+                    "html",
+                ],
+            ),
+            (
+                nsstring_to_string(cocoa::appkit::NSPasteboardTypeRTF),
+                vec!["public.rtf", "application/rtf", "rtf"],
+            ),
+        ])
+    })
+};
+
+pub struct MacBackend {}
+
+impl ClipBackend for MacBackend {
+    fn copy(&self, config: CopyConfig) -> Result<()> {
+        unsafe { copy_mac(config) }
+    }
+
+    fn paste(&self, config: PasteConfig) -> Result<()> {
+        unsafe { paste_mac(config) }
+    }
+}
+
+unsafe fn copy_mac(config: CopyConfig) -> Result<()> {
+    let _pool = NSAutoreleasePool::new(nil);
+
+    let pb = NSPasteboard::generalPasteboard(nil);
+    let types = config.source_data.mime_types();
+
+    pb.clearContents();
+
+    for t in &types {
+        let ns_pb_type = match_ns_pasteboard_type(t);
+        if ns_pb_type.is_empty() {
+            bail!("Failed to copy content of type {t}")
+        }
+        let res = config.source_data.content_by_mime_type(t);
+        if !res.0 {
+            log::warn!("No content found fro {t}");
+            continue;
+        }
+        let nstr_type = NSString::alloc(nil).init_str(ns_pb_type.as_str());
+        let bytes = res.1.as_ptr() as *const std::os::raw::c_void;
+        let length = res.1.len() as u64;
+        let nsdata = NSData::dataWithBytesNoCopy_length_(nil, bytes, length);
+        let r = pb.setData_forType(nsdata, nstr_type);
+        if r != 1 {
+            log::error!("Failed to call setData_forType on {t}");
+        }
+    }
+
+    Ok(())
+}
+
+unsafe fn paste_mac(config: PasteConfig) -> Result<()> {
+    let _pool = NSAutoreleasePool::new(nil);
+
+    let mut writer = config.writter;
+    let mut type_list: Vec<String> = vec![];
+
+    let pb = NSPasteboard::generalPasteboard(nil);
+    let types = pb.types();
+    let count = types.count();
+
+    for i in 0..count {
+        let t = types.objectAtIndex(i);
+        let str = nsstring_to_string(t);
+        if SUPPORTED_TYPES_MAP.contains_key(&str) {
+            type_list.push(str);
+        }
+    }
+
+    if config.list_types_only {
+        for str in type_list {
+            writeln!(&mut writer, "{}", str).context("Failed to write to the output")?;
+        }
+        return Ok(());
+    }
+
+    let expected_type = match_ns_pasteboard_type(&config.expected_mime_type);
+    if expected_type.is_empty() {
+        bail!(
+            "Content for mime-type {} doesn't exist",
+            config.expected_mime_type
+        )
+    }
+
+    let nstr_type = NSString::alloc(nil).init_str(expected_type.as_str());
+    let data = pb.dataForType(nstr_type);
+    let bytes = data.bytes() as *const u8;
+    let length = data.length() as usize;
+    let slice = std::slice::from_raw_parts(bytes, length);
+    writer.write_all(slice)?;
+    writer.flush()?;
+
+    Ok(())
+}
+
+unsafe fn nsstring_to_string(ns_str: id) -> String {
+    let c_str: *const i8 = NSString::UTF8String(ns_str);
+
+    if c_str.is_null() {
+        panic!("Empty or null NSString content");
+    }
+
+    CStr::from_ptr(c_str)
+        .to_str()
+        .expect("Invalid UTF-8 string")
+        .to_string()
+}
+
+unsafe fn match_ns_pasteboard_type(mime_type: &str) -> String {
+    if !mime_type.is_empty() {
+        let target = mime_type.to_lowercase();
+        if let Some((key, _)) = SUPPORTED_TYPES_MAP
+            .iter()
+            .find(|(_, types)| types.iter().any(|s| s.to_lowercase().contains(&target)))
+        {
+            key.clone()
+        } else {
+            "".to_string()
+        }
+    } else {
+        nsstring_to_string(appkit::NSPasteboardTypeString)
+    }
+}

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -1,10 +1,14 @@
+#[cfg(target_os = "macos")]
+mod mac;
 mod mime_type;
 #[cfg(target_os = "linux")]
 mod wayland;
 mod x;
 
 use super::protocol::SourceData;
-use anyhow::{bail, Result};
+#[cfg(target_os = "linux")]
+use anyhow::bail;
+use anyhow::Result;
 use std::io::Write;
 
 pub trait ClipBackend {
@@ -27,10 +31,13 @@ pub struct CopyConfig {
     pub x_chunk_size: usize,
 }
 
-pub use x::XBackend;
+#[cfg(target_os = "macos")]
+use mac::MacBackend;
 
 #[cfg(target_os = "linux")]
 pub use wayland::WaylandBackend;
+#[cfg(target_os = "linux")]
+pub use x::XBackend;
 
 #[cfg(target_os = "linux")]
 pub fn create_backend() -> Result<Box<dyn ClipBackend>> {
@@ -45,9 +52,12 @@ pub fn create_backend() -> Result<Box<dyn ClipBackend>> {
 
 #[cfg(target_os = "macos")]
 pub fn create_backend() -> Result<Box<dyn ClipBackend>> {
-    if std::env::var("DISPLAY").is_ok() {
-        return Ok(Box::new(XBackend {}));
-    }
+    // NOTE: X clipboard can be supported on Mac if Mac has Xserver installed like XQuartz.
+    //       However it doesn't make too much sense since XQuartz should be above to read/write the
+    //       cocoa pasteboard.
+    // if std::env::var("DISPLAY").is_ok() {
+    //     return Ok(Box::new(XBackend {}));
+    // }
 
-    bail!("Could not decide the clip backend");
+    Ok(Box::new(MacBackend {}))
 }


### PR DESCRIPTION
- Unlike X/wayland, the copied data will be put into a system-wide shared memory, richclip process doesn't have to be alive to keep the copied content.
- Only support some types of data for cocoa.
- Cocoa programming is really strange, don't like it.