### PR TITLE
feat: add X11 fallback for Wayland compositors

### DIFF
--- a/src/clipboard/wayland.rs
+++ b/src/clipboard/wayland.rs
@@ -21,6 +21,10 @@ use wayrs_protocols::wlr_data_control_unstable_v1::{
 
 pub struct WaylandBackend {}
 
+pub fn test_protocol_available() -> bool {
+    create_wayland_client::<()>().is_ok()
+}
+
 struct WaylandClient<T> {
     conn: Connection<T>,
     seat: WlSeat,
@@ -62,8 +66,10 @@ fn create_wayland_client<T>() -> Result<WaylandClient<T>> {
     conn.blocking_roundtrip()
         .context("Failed to call 'blocking_roundtrip'")?;
 
-    let seat: WlSeat = conn.bind_singleton(2..=4).context("")?;
-    let data_ctl_mgr: ZwlrDataControlManagerV1 = conn.bind_singleton(..=2).context("")?;
+    let seat: WlSeat = conn
+        .bind_singleton(2..=4)
+        .context("Failed to bind Wayland seat")?;
+    let data_ctl_mgr: ZwlrDataControlManagerV1 = conn.bind_singleton(..=2).context("Failed to bind data control manager (wlr_data_control_unstable_v1 protocol may not be available)")?;
 
     Ok(WaylandClient::<T> {
         conn,


### PR DESCRIPTION
Add test_protocol_available() function to check if the wlr_data_control
protocol is available before selecting the Wayland backend. This allows
richclip to fall back to X11 when running on Wayland compositors that
don't support the wlroots-specific protocol (e.g., WSLg, GNOME Mutter).
Also improve error messages for bind_singleton failures to make debugging
easier when the protocol is not available.
